### PR TITLE
Update Jenkinsfile to reflect new file structure

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,7 @@ pipeline {
         
         stage('Build') {
             steps {
-                sh 'flit build'
+                sh 'python3 -m build ./passwords'
             }
         }
 
@@ -31,7 +31,7 @@ pipeline {
                     passwordVariable: 'PYPI_PASSWORD'
                 )]) {
                     sh 'python3 -m pip install -U twine'
-                    sh 'python3 -m twine upload dist/\\* -u$PYPI_USERNAME -p$PYPI_PASSWORD'
+                    sh 'python3 -m twine upload ./passwords/dist/\\* -u$PYPI_USERNAME -p$PYPI_PASSWORD'
                 }
             }
         }


### PR DESCRIPTION
## Changes

- Build the files inside of ./passwords folder rather than the root directory
    - Jenkins was raising an error about how no pyproject.toml could be found in the root directory

## How was this tested?

- Untested. I'll be able to test it next time we update the passwords package